### PR TITLE
Initial Arquillian Test Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.settings
 *.iml
 .idea
+**/target

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <module>webportal-comms</module>
         <module>webportal-root</module>
         <module>webportal-ear</module>
+        <module>tests</module>
     </modules>
 
     <repositories>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--                                                                                                          -->
+<!-- Copyright (c) 2013-2015, Arjuna Technologies Limited, Newcastle-upon-Tyne, England. All rights reserved. -->
+<!--                                                                                                          -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.arjuna.databroker</groupId>
+    <version>1.0.0p1m2l</version>
+    <artifactId>tests</artifactId>
+    <packaging>jar</packaging>
+    <name>DataBroker Test Jar</name>
+
+    <dependencyManagement>
+        <dependencies>
+           <dependency>
+               <groupId>org.jboss.arquillian</groupId>
+               <artifactId>arquillian-bom</artifactId>
+               <version>1.1.5.Final</version>
+               <scope>import</scope>
+               <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+       <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.8.1</version>
+       </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-arquillian-container-managed</artifactId>
+            <version>8.1.0.Final</version>
+         </dependency>
+         <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+         </dependency>
+      </dependencies>
+
+      <build>
+         <plugins>
+            <plugin>
+               <groupId>org.apache.maven.plugins</groupId>
+               <artifactId>maven-surefire-plugin</artifactId>
+               <version>2.17</version>
+               <configuration>
+                  <!-- Fork every test because it will launch a separate AS instance -->
+                  <forkMode>always</forkMode>
+                  <systemPropertyVariables>
+                     <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                  </systemPropertyVariables>
+                  <redirectTestOutputToFile>false</redirectTestOutputToFile>
+               </configuration>
+            </plugin>
+         </plugins>
+      </build>
+</project>

--- a/tests/src/test/java/org/risbic/databroker/tests/ExampleTest.java
+++ b/tests/src/test/java/org/risbic/databroker/tests/ExampleTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.risbic.databroker.tests;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author mtaylor
+ */
+
+@RunWith(Arquillian.class)
+public class ExampleTest
+{
+   @Test
+   public void exampleTest()
+   {
+
+   }
+}


### PR DESCRIPTION
Adds initial Arquillian support.  There is an example test to show the application server being started.  I'll follow up with a real test using ShrinkWrap.  This PR is only to add the Arquillian setup.  

To run:

```bash
export JBOSS_HOME=`path to wildfly`
cd DataBroker/tests
mvn clean test
```
